### PR TITLE
Updated iDaaS-Connect-HL7

### DIFF
--- a/iDaaS-Connect-HL7/src/main/java/io/connectedhealth_idaas/hl7/ConfigProperties.java
+++ b/iDaaS-Connect-HL7/src/main/java/io/connectedhealth_idaas/hl7/ConfigProperties.java
@@ -63,6 +63,7 @@ public class ConfigProperties {
     private String schTopicName;
     private String vxuTopicName;
     private String ccdaTopicName;
+    private String hl7HTTPTopicName;
 
     // Getters and Setters by Usage
     public String getConvertCCDAtoFHIR() {return convertCCDAtoFHIR;}
@@ -241,5 +242,8 @@ public class ConfigProperties {
     public void setCcdaTopicName(String ccdaTopicName) {
         this.ccdaTopicName = ccdaTopicName;
     }
+    public String getHl7HTTPTopicName() { return hl7HTTPTopicName; }
+    public void setHl7HTTPTopicName(String hl7HTTPTopicName) { this.hl7HTTPTopicName = hl7HTTPTopicName; }
+
 
 }

--- a/iDaaS-Connect-HL7/src/main/resources/application.properties
+++ b/iDaaS-Connect-HL7/src/main/resources/application.properties
@@ -63,6 +63,8 @@ idaas.vxuTopicName=mctn_mms_vxu
 # CCDA
 idaas.hl7ccda_Directory=data-input/ccda
 idaas.ccdaTopicName=mctn_mms_ccda
+# HL7 over HTTP
+idaas.hl7HTTPTopicName=mctn_mms_hl7http
 # Other Settings
 idaas.convertCCDAtoFHIR=true
 idaas.convertHL7toFHIR=true


### PR DESCRIPTION
 updated application.properties, and the CamelConfiguration.java to include an /hl7 endpoint to support HL7 over HTTP data transport including the settings to convert to FHIR automatically (if the property is set to true).