### PR TITLE
Updates:

### DIFF
--- a/iDaaS-Connect-FHIR/src/main/java/io/connectedhealth_idaas/fhir/ConfigProperties.java
+++ b/iDaaS-Connect-FHIR/src/main/java/io/connectedhealth_idaas/fhir/ConfigProperties.java
@@ -82,5 +82,5 @@ public class ConfigProperties {
 
     public Boolean getProcessPublicCloud() { return processPublicCloud;}
     public void setProcessPublicCloud(Boolean processPublicCloud) {this.processPublicCloud = processPublicCloud; }
-}
+
 }

--- a/iDaaS-Connect-SAP/src/main/java/io/connectedhealth_idaas/sap/ConfigProperties.java
+++ b/iDaaS-Connect-SAP/src/main/java/io/connectedhealth_idaas/sap/ConfigProperties.java
@@ -28,8 +28,7 @@ public class ConfigProperties {
     // Public Cloud
     private String cloudTopic;
     private String cloudAPI;
-    private Boolean processsPublicCloud;
-
+    private Boolean processPublicCloud;
 
     public String getKafkaBrokers() {
         return kafkaBrokers;
@@ -47,6 +46,7 @@ public class ConfigProperties {
     public String getCloudAPI() { return cloudAPI; }
     public void setCloudAPI(String cloudAPI) { this.cloudAPI = cloudAPI;}
 
-    public Boolean getProcessPublicCloud() { return processPublicCloud;}
-    public void setProcessPublicCloud(Boolean processPublicCloud) {this.processPublicCloud = processPublicCloud; }
+    public Boolean getProcessPublicCloud() { return processPublicCloud; }
+
+    public void setProcessPublicCloud(Boolean processPublicCloud) { this.processPublicCloud = processPublicCloud; }
 }


### PR DESCRIPTION
- Resolved issue with iDaaS-Connect-FHIR, ConfigProperties.java with a duplicate character } which caused it to fail.

- Resolved issue with iDaaS-Connect-SAP, ConfigProperties.java needed to have processPublicCloud reference redefined and getters and setters re-defined.